### PR TITLE
Better docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+docker/mongo/db

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+indent_size = 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ COPY package*.json ./
 RUN npm install --no-optional && npm cache clean --force
 ENV PATH /opt/api/node_modules/.bin:$PATH
 
-WORKDIR /opt/api/app
-
 COPY . .
 
 EXPOSE 3030
-CMD /wait && supervisor --quiet --watch . --extensions js -- index.js
+CMD /wait && npm run watch

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ docker-compose up
 To reach a shell inside the container, use
 
 ```bash
-docker-compose run --service-ports --rm api /bin/bash
+npm run docker
 ```
 
-At which point you can `node index.js`.
+At which point you can `npm run watch` or simply `node .`.
 
 
 ### Routes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,19 +4,21 @@ services:
   api:
     build:
       context: .
-      dockerfile: ./Dockerfile
+      dockerfile: ./docker/development.Dockerfile
     stdin_open: true
     tty: true
     ports:
       - 3030:3030
     volumes:
-      - ./:/opt/api/app:delegated
+      - ./:/opt/api:delegated
     environment:
       - NODE_ENV=development
       - WAIT_HOSTS=mongo:27017
       - YAYHOORAY_API_PORT=3030
-      - YAYHOORAY_MONGODB_URL=mongodb://mongo:27017/yayhooray
+      - YAYHOORAY_MONGODB_URL=mongodb://yay:hooray@mongo:27017/yayhooray
       - YAYHOORAY_JWT_SECRET=dontUseThisSecretInProduction
+      - YAYHOORAY_MAX_URLNAME_ATTEMPTS=10
+      - YAYHOORAY_ALLOWED_CATEGORIES=Advice,Discussions,Meaningless,Projects
     depends_on:
       - mongo
 
@@ -26,11 +28,12 @@ services:
     ports:
       - 27017:27017
     environment:
-      - MONGO_INITDB_DATABASE=yayhoory
+      - MONGO_INITDB_DATABASE=yayhooray
       - MONGO_INITDB_ROOT_USERNAME=yay
       - MONGO_INITDB_ROOT_PASSWORD=hooray
     volumes:
-      - ./tmp/mongo:/data/db
+      - ./docker/mongo/tmp:/data/db
+      - ./docker/mongo/init.sh:/docker-entrypoint-initdb.d/init.sh
 
 networks:
   default:

--- a/docker/development.Dockerfile
+++ b/docker/development.Dockerfile
@@ -1,0 +1,23 @@
+FROM node:12.16.1
+
+# for cleanly waiting on mongodb
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.7.3/wait /wait
+RUN chmod +x /wait
+
+# for managing a running mongodb instance
+RUN wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | apt-key add - \
+	&& apt-get update \
+	&& apt-get install apt-transport-https \
+	&& echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.2.list \
+ 	&& apt-get update \
+ 	&& apt-get install mongodb-org-tools \
+ 	&& apt-get autoremove && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g supervisor
+
+WORKDIR /opt/api
+COPY . .
+RUN npm install
+
+EXPOSE 3030
+CMD /wait && npm run watch

--- a/docker/mongo/init.sh
+++ b/docker/mongo/init.sh
@@ -1,0 +1,12 @@
+mongo -- "$MONGO_INITDB_DATABASE" <<EOF
+  db.createUser({
+    user: "$MONGO_INITDB_ROOT_USERNAME",
+    pwd: "$MONGO_INITDB_ROOT_PASSWORD",
+    roles: ["dbOwner"]
+  })
+
+  db.getSiblingDB('admin').auth(
+    "$MONGO_INITDB_ROOT_USERNAME",
+    "$MONGO_INITDB_ROOT_PASSWORD"
+  )
+EOF

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "API for yayhooray",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "docker": "docker-compose run --service-ports --rm api /bin/bash",
+    "watch": "supervisor --quiet --watch . --extensions js -- index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously I was using a trick to make sure that docker-installed js dependencies stayed inside the image. This works badly in practice. `docker-compose build app` now installs packages in the base of the codebase like it should be.

I was unaware that the mongo container needed an explicit startup script to create the database on first-run. `yayhooray` is now created if it doesnt exist. Along with this, the proper mongo_url is supplied to the internal node environment.

I committed a .dockerignore to prevent the mongodb data from entering the docker context when building images.

The .editorconfig should have been a separate commit, if you hate the idea ill can that one. A proper linter file would also takes its place. Which one do you use?
I dropped some often used commands into the package.json so i could `npm run docker`. That look alright to you?